### PR TITLE
Add 'FindByUniversity' command and related tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,9 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MAJOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_UNIVERSITY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -48,7 +50,9 @@ public class EditCommand extends Command {
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_EMAIL + "johndoe@example.com"
+            + PREFIX_UNIVERSITY + "NUS"
+            + PREFIX_MAJOR + "Computer Science";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -144,6 +148,8 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private University university;
+        private Major major;
 
         public EditPersonDescriptor() {}
 
@@ -157,6 +163,8 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setUniversity(toCopy.university);
+            setMajor(toCopy.major);
         }
 
         /**
@@ -215,6 +223,22 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        public void setUniversity(University university) {
+            this.university = university;
+        }
+
+        public Optional<University> getUniversity() {
+            return Optional.ofNullable(university);
+        }
+
+        public void setMajor(Major major) {
+            this.major = major;
+        }
+
+        public Optional<Major> getMajor() {
+            return Optional.ofNullable(major);
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -231,7 +255,9 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags)
+                    && Objects.equals(university, otherEditPersonDescriptor.university)
+                    && Objects.equals(major, otherEditPersonDescriptor.major);
         }
 
         @Override
@@ -242,6 +268,8 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("tags", tags)
+                    .add("university", university)
+                    .add("major", major)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/commands/FindByUniversityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByUniversityCommand.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.UniversityContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose university contains the argument keyword.
+ * Keyword matching is case-insensitive.
+ */
+public class FindByUniversityCommand extends Command {
+
+    public static final String COMMAND_WORD = "findu";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose universities contain "
+            + "the specified keyword (case-insensitive) and displays them as a list.\n"
+            + "Parameters: u/KEYWORD\n"
+            + "Example: " + COMMAND_WORD + " u/NUS";
+
+    private final UniversityContainsKeywordsPredicate predicate;
+
+    public FindByUniversityCommand(UniversityContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindByUniversityCommand // instanceof handles nulls
+                && predicate.equals(((FindByUniversityCommand) other).predicate));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindByUniversityCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case FindByUniversityCommand.COMMAND_WORD:
+            return new FindByUniversityCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/FindByUniversityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindByUniversityCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.FindByUniversityCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.UniversityContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new {@code FindByUniversityCommand} object.
+ */
+public class FindByUniversityCommandParser implements Parser<FindByUniversityCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code FindByUniversityCommand}
+     * and returns a {@code FindByUniversityCommand} object for execution.
+     *
+     * @param args The arguments provided by the user.
+     * @return A new {@code FindByUniversityCommand} object based on the parsed arguments.
+     * @throws ParseException If the user input does not conform to the expected format.
+     */
+    public FindByUniversityCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        // Check if the input is empty or doesn't start with the correct format ("u/")
+        if (trimmedArgs.isEmpty() || !trimmedArgs.startsWith("u/")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByUniversityCommand.MESSAGE_USAGE));
+        }
+
+        // Extract the university keyword after "u/" and trim any unnecessary spaces
+        String universityKeyword = trimmedArgs.substring(2).trim();
+
+        // Ensure that the university keyword is not empty after trimming
+        if (universityKeyword.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByUniversityCommand.MESSAGE_USAGE));
+        }
+
+        // Return a new FindByUniversityCommand with the parsed university keyword
+        return new FindByUniversityCommand(
+                new UniversityContainsKeywordsPredicate(universityKeyword)
+        );
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -151,5 +151,4 @@ public class Person {
                 .add("experience", experience)
                 .toString();
     }
-
 }

--- a/src/main/java/seedu/address/model/person/UniversityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/UniversityContainsKeywordsPredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code University} matches the keyword given.
+ */
+public class UniversityContainsKeywordsPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public UniversityContainsKeywordsPredicate(String keyword) {
+        this.keyword = keyword.toLowerCase();
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return StringUtil.containsWordIgnoreCase(person.getUniversity().value, keyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof UniversityContainsKeywordsPredicate
+                && keyword.equals(((UniversityContainsKeywordsPredicate) other).keyword));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindByUniversityCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByUniversityCommandTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.UniversityContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindByUniversityCommand}.
+ */
+public class FindByUniversityCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    /**
+     * Tests if the equals() method correctly identifies equivalent and non-equivalent commands.
+     */
+    @Test
+    public void equals() {
+        UniversityContainsKeywordsPredicate firstPredicate =
+                new UniversityContainsKeywordsPredicate("NUS");
+        UniversityContainsKeywordsPredicate secondPredicate =
+                new UniversityContainsKeywordsPredicate("NTU");
+
+        FindByUniversityCommand findFirstCommand = new FindByUniversityCommand(firstPredicate);
+        FindByUniversityCommand findSecondCommand = new FindByUniversityCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindByUniversityCommand findFirstCommandCopy = new FindByUniversityCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different university -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    /**
+     * Tests if the command execution with zero keywords finds no matching persons.
+     */
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        UniversityContainsKeywordsPredicate predicate = new UniversityContainsKeywordsPredicate(" ");
+        FindByUniversityCommand command = new FindByUniversityCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests if the command execution with a single valid keyword finds multiple matching persons.
+     */
+    @Test
+    public void execute_singleKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        UniversityContainsKeywordsPredicate predicate = new UniversityContainsKeywordsPredicate("NUS");
+        FindByUniversityCommand command = new FindByUniversityCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests if the toString method provides the correct string representation of the command.
+     */
+    @Test
+    public void toStringMethod() {
+        UniversityContainsKeywordsPredicate predicate = new UniversityContainsKeywordsPredicate("NUS");
+        FindByUniversityCommand findCommand = new FindByUniversityCommand(predicate);
+        String expected = FindByUniversityCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindByUniversityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindByUniversityCommandParserTest.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindByUniversityCommand;
+import seedu.address.model.person.UniversityContainsKeywordsPredicate;
+
+public class FindByUniversityCommandParserTest {
+
+    private FindByUniversityCommandParser parser = new FindByUniversityCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        // Test for empty input
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByUniversityCommand.MESSAGE_USAGE));
+
+        // Test for missing 'u/' prefix
+        assertParseFailure(parser, "NUS", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByUniversityCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindByUniversityCommand() {
+        // Test with valid single keyword input
+        FindByUniversityCommand expectedCommand =
+                new FindByUniversityCommand(new UniversityContainsKeywordsPredicate("NUS"));
+        assertParseSuccess(parser, "u/NUS", expectedCommand);
+
+        // Test with leading and trailing spaces
+        assertParseSuccess(parser, " u/NUS ", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidPrefix_throwsParseException() {
+        // Test with invalid prefix (does not start with 'u/')
+        assertParseFailure(parser, "n/NUS", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByUniversityCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleSpaces_returnsTrimmedFindByUniversityCommand() {
+        // Test input with multiple spaces
+        FindByUniversityCommand expectedCommand =
+                new FindByUniversityCommand(new UniversityContainsKeywordsPredicate("NUS"));
+        assertParseSuccess(parser, " u/   NUS   ", expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -14,8 +14,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Major;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.University;
+
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -23,11 +26,16 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_UNIVERSITY = "";
+    private static final String INVALID_MAJOR = "";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_UNIVERSITY = BENSON.getUniversity().toString();
+    private static final String VALID_MAJOR = BENSON.getMajor().toString();
+
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,14 +49,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +66,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +83,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS,
+                        VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS,
+                VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +100,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
+                        VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS,
+                VALID_UNIVERSITY, VALID_MAJOR);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +119,40 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
+                        VALID_UNIVERSITY, VALID_MAJOR);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+    @Test
+    public void toModelType_invalidUniversity_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, INVALID_UNIVERSITY, VALID_MAJOR);
+        String expectedMessage = University.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullUniversity_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, null, VALID_MAJOR);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, University.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidMajorthrowsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_UNIVERSITY, INVALID_MAJOR);
+        String expectedMessage = University.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullMajor_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_UNIVERSITY, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, University.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -7,9 +7,11 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Major;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.University;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -37,6 +39,8 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
+        descriptor.setUniversity(person.getUniversity());
+        descriptor.setMajor(person.getMajor());
     }
 
     /**
@@ -78,6 +82,22 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Sets the {@code University} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withUniversity(String university) {
+        descriptor.setUniversity(new University(university));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Major} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withMajor(String major) {
+        descriptor.setMajor(new Major(major));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -5,9 +5,11 @@ import java.util.Set;
 
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Major;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.University;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -20,12 +22,16 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_UNIVERSITY = "NUS";
+    public static final String DEFAULT_MAJOR = "Computer Science";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private University university;
+    private Major major;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +42,8 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        university = new University(DEFAULT_UNIVERSITY);
+        major = new Major(DEFAULT_MAJOR);
     }
 
     /**
@@ -47,6 +55,8 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        university = personToCopy.getUniversity();
+        major = personToCopy.getMajor();
     }
 
     /**
@@ -89,8 +99,24 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code University} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withUniversity(String university) {
+        this.university = new University(university);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Major} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withMajor(String major) {
+        this.major = new Major(major);
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, university, major);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,11 +26,16 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").build();
+            .withTags("friends")
+            .withUniversity("NUS")
+            .withMajor("Computer Science").build();
+
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends")
+            .withUniversity("NTU")
+            .withMajor("Computer Science").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
- Implemented `FindByUniversityCommand` and `FindByUniversityCommandParser` to allow searching for persons by university.
- Added tests for `FindByUniversityCommand` and `FindByUniversityCommandParser`.
- Updated `UniversityContainsKeywordsPredicate` to filter persons by university.
- Updated `Person`, `PersonBuilder`, and `EditPersonDescriptorBuilder` to include university and major fields.
- Added handling for `university` and `major` fields in `JsonAdaptedPersonTest`.
- Minor adjustments in `EditCommand` to ensure university and major fields are accounted for during edits.

Tests:
- Added integration and unit tests for `FindByUniversityCommand`.
- Verified JSON adaptations for university and major fields.
Fixes #41 