### PR TITLE
Add addi command for users to add interests to existing contacts

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInterestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInterestCommand.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTEREST;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Interest;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds interests to an existing person in the address book.
+ */
+public class AddInterestCommand extends Command {
+
+    public static final String COMMAND_WORD = "addi";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds interests to the specified person. "
+            + "Parameters: "
+            + PREFIX_INDEX + "INDEX "
+            + PREFIX_INTEREST + "INTEREST \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_INDEX + "1 "
+            + PREFIX_INTEREST + "Swimming "
+            + PREFIX_INTEREST + "Hiking\n";
+
+    public static final String MESSAGE_SUCCESS = "New interests added to %1$s: %2$s";
+    public static final String MESSAGE_DUPLICATE_INTERESTS = "This person already has some of the interests: %1$s";
+    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
+
+    private final Index index;
+    private final Set<Interest> interestsToAdd;
+
+    /**
+     * Creates an AddInterestCommand to add the specified {@code interests} to a person.
+     */
+    public AddInterestCommand(Index index, Set<Interest> interests) {
+        requireNonNull(index);
+        requireNonNull(interests);
+        this.index = index;
+        this.interestsToAdd = interests;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        // Get current interests
+        Set<Interest> currentInterests = new HashSet<>(personToEdit.getInterests());
+
+        // Normalize interests for case-insensitive comparison
+        Set<String> currentInterestNamesLowerCase = currentInterests.stream()
+                .map(interest -> interest.interestName.toLowerCase())
+                .collect(Collectors.toSet());
+
+        // Check for case-insensitive duplicates within the new interests provided
+        Set<String> newInterestNamesLowerCase = new HashSet<>();
+        Set<Interest> duplicateInterests = new HashSet<>();
+        Set<Interest> validInterestsToAdd = new HashSet<>();
+
+        for (Interest interest : interestsToAdd) {
+            String interestNameLowercase = interest.interestName.toLowerCase();
+
+            // Check if the interest already exists in the person's current interests or is a duplicate in the command
+            if (currentInterestNamesLowerCase.contains(interestNameLowercase)
+                    || !newInterestNamesLowerCase.add(interestNameLowercase)) {
+                duplicateInterests.add(interest);
+            } else {
+                validInterestsToAdd.add(interest);
+            }
+        }
+
+        // If all interests are duplicates, throw an error
+        if (validInterestsToAdd.isEmpty() && !duplicateInterests.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_INTERESTS, duplicateInterests));
+        }
+
+        // Add new interests to current interests
+        currentInterests.addAll(validInterestsToAdd);
+
+        // Create the updated person with new interests
+        Person editedPerson = new Person(
+                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getWorkExp(),
+                personToEdit.getTags(), personToEdit.getUniversity(), personToEdit.getMajor(), currentInterests);
+
+        // Update the person in the model
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, personToEdit.getName(), validInterestsToAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddInterestCommand // instanceof handles nulls
+                && index.equals(((AddInterestCommand) other).index)
+                && interestsToAdd.equals(((AddInterestCommand) other).interestsToAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddInterestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddInterestCommandParser.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTEREST;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddInterestCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Interest;
+
+/**
+ * Parses input arguments and creates a new AddInterestCommand object.
+ */
+public class AddInterestCommandParser implements Parser<AddInterestCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddInterestCommand
+     * and returns an AddInterestCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public AddInterestCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX, PREFIX_INTEREST);
+
+        if (!argMultimap.getValue(PREFIX_INDEX).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterestCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterestCommand.MESSAGE_USAGE),
+                    pe);
+        }
+
+        List<String> interestStrings = argMultimap.getAllValues(PREFIX_INTEREST);
+        if (interestStrings.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterestCommand.MESSAGE_USAGE));
+        }
+
+        Set<Interest> interests = new HashSet<>();
+        for (String interestStr : interestStrings) {
+            Interest interest = ParserUtil.parseInterest(interestStr);
+            if (!interests.add(interest)) {
+                throw new ParseException(AddInterestCommand.MESSAGE_DUPLICATE_INTERESTS);
+            }
+        }
+
+        return new AddInterestCommand(index, interests);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddInterestCommand;
 import seedu.address.logic.commands.AddWorkExperienceCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -59,6 +60,9 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddInterestCommand.COMMAND_WORD:
+            return new AddInterestCommandParser().parse(arguments);
 
         case AddWorkExperienceCommand.COMMAND_WORD:
             return new AddWorkExperienceCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -183,4 +183,16 @@ public class ParserUtil {
         }
         return interestSet;
     }
+    /**
+     * Parses a {@code String interest} into an {@code Interest}.
+     * @throws ParseException if the given {@code interest} is invalid.
+     */
+    public static Interest parseInterest(String interest) throws ParseException {
+        requireNonNull(interest);
+        String trimmedInterest = interest.trim();
+        if (!Interest.isValidInterest(trimmedInterest)) {
+            throw new ParseException(Interest.MESSAGE_CONSTRAINTS);
+        }
+        return new Interest(trimmedInterest);
+    }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -145,4 +145,5 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(otherModelManager.filteredPersons);
     }
 
+
 }

--- a/src/test/java/seedu/address/logic/commands/AddInterestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInterestCommandTest.java
@@ -1,0 +1,102 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Interest;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class AddInterestCommandTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_addDuplicateInterest_failure() {
+        // Trying to add an interest that already exists
+        Set<Interest> duplicateInterest = Set.of(new Interest("Swimming")); // Case-insensitive duplicate
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        AddInterestCommand addInterestCommand = new AddInterestCommand(INDEX_FIRST_PERSON, duplicateInterest);
+
+        String expectedMessage = String.format(AddInterestCommand.MESSAGE_DUPLICATE_INTERESTS, "[Swimming]");
+
+        assertCommandFailure(addInterestCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidPersonIndex_failure() {
+        Set<Interest> newInterests = Set.of(new Interest("Swimming"));
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AddInterestCommand addInterestCommand = new AddInterestCommand(outOfBoundIndex, newInterests);
+
+        assertCommandFailure(addInterestCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_addDuplicateCaseInsensitiveInterest_throwsCommandException() {
+        Set<Interest> duplicateInterest = Set.of(new Interest("Swimming")); // Case-insensitive duplicate
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        AddInterestCommand addInterestCommand = new AddInterestCommand(INDEX_FIRST_PERSON, duplicateInterest);
+
+        String expectedMessage = String.format(AddInterestCommand.MESSAGE_DUPLICATE_INTERESTS, duplicateInterest);
+
+        assertCommandFailure(addInterestCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_addNewInterest_success() throws Exception {
+        Set<Interest> newInterests = Set.of(new Interest("Hiking"));
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // Combine current and new interests for expected result
+        Set<Interest> combinedInterests = new HashSet<>(personToEdit.getInterests());
+        combinedInterests.addAll(newInterests);
+
+        // Convert to String[] for PersonBuilder
+        String[] combinedInterestsArray = combinedInterests.stream()
+                .map(Interest::toString)
+                .toArray(String[]::new);
+
+        Person editedPerson = new PersonBuilder(personToEdit).withInterests(combinedInterestsArray).build();
+        AddInterestCommand addInterestCommand = new AddInterestCommand(INDEX_FIRST_PERSON, newInterests);
+
+        String expectedMessage = String.format(AddInterestCommand.MESSAGE_SUCCESS, personToEdit.getName(),
+                newInterests);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToEdit, editedPerson);
+
+        assertCommandSuccess(addInterestCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_addDuplicateInterestsInCommand_throwsCommandException() {
+        Set<Interest> interests = Set.of(new Interest("Swimming"), new Interest("swimming"));
+        AddInterestCommand addInterestCommand = new AddInterestCommand(INDEX_FIRST_PERSON, interests);
+
+        String expectedMessage = "This person already has some of the interests: [swimming, Swimming]";
+
+        assertCommandFailure(addInterestCommand, model, expectedMessage);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddInterestCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddInterestCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddInterestCommand;
+import seedu.address.model.person.Interest;
+
+public class AddInterestCommandParserTest {
+
+    private final AddInterestCommandParser parser = new AddInterestCommandParser();
+    @Test
+    public void parse_validArgs_returnsAddInterestCommand() {
+        // Test valid input with all fields
+        Index index = Index.fromOneBased(1);
+        Set<Interest> interest = Set.of(new Interest("Swimming"));
+        AddInterestCommand expectedCommand = new AddInterestCommand(index, interest);
+        assertParseSuccess(parser, " in/1 i/Swimming", expectedCommand);
+    }
+
+    @Test
+    public void parseInvalidArgs_missingIndex_throwsParseException() {
+        // Test input with missing index
+        assertParseFailure(parser, " i/Hiking", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddInterestCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        // Invalid index provided
+        assertParseFailure(parser, "in/a i/Swimming",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterestCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noInterestsProvided_throwsParseException() {
+        // Missing interests in the command
+        assertParseFailure(parser, "in/1 i/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInterestCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Fixes #90 

Fix(parser): correctly handle multiple interests in `AddInterestCommandParser`

- Updated `AddInterestCommandParser` to properly parse and handle multiple interest inputs (e.g., `i/Swimming i/Hiking`)
- Implemented case-insensitive duplicate interest checking within the command
- Added validation to ensure at least one valid interest is provided in the command
- Fixed unit tests to reflect the new parsing logic for multiple interests

Resolves issue where the parser incorrectly handled multiple interest inputs or allowed duplicates in a case-insensitive manner.
