### PR TITLE
Fix alpha bug, change duplicity check to phone numbers instead of names

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -64,9 +64,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public boolean hasPerson(Person person) {
         requireNonNull(person);
-        return persons.contains(person);
+        return persons.asUnmodifiableObservableList().stream()
+                .anyMatch(existingPerson -> existingPerson.getPhone().equals(person.getPhone()));
     }
-
     /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -108,7 +107,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getPhone().equals(getPhone());
     }
 
     /**
@@ -127,22 +126,14 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
-        return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
-                && workExp.equals(otherPerson.workExp)
-                && tags.equals(otherPerson.tags)
-                && university.equals(otherPerson.university)
-                && major.equals(otherPerson.major)
-                && interests.equals(otherPerson.interests)
-                && birthday.equals(otherPerson.birthday);
+        return this.phone.equals(otherPerson.phone);
+
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, workExp, tags, university, major, interests);
+        return phone.hashCode();
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -55,8 +55,8 @@ public class AddCommandTest {
 
     @Test
     public void equals() {
-        Person alice = new PersonBuilder().withName("Alice").build();
-        Person bob = new PersonBuilder().withName("Bob").build();
+        Person alice = new PersonBuilder().withName("Alice").withPhone("12345678").build();
+        Person bob = new PersonBuilder().withName("Bob").withPhone("12345678").build();
         AddCommand addAliceCommand = new AddCommand(alice);
         AddCommand addBobCommand = new AddCommand(bob);
 
@@ -74,7 +74,9 @@ public class AddCommandTest {
         assertFalse(addAliceCommand.equals(null));
 
         // different person -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        Person charlie = new PersonBuilder().withName("Charlie").withPhone("87654321").build();
+        AddCommand addCharlieCommand = new AddCommand(charlie);
+        assertFalse(addAliceCommand.equals(addCharlieCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -35,6 +35,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_ALICE = "94351253";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_INTEREST_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_INTEREST_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MAJOR_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_UNIVERSITY_BOB;
@@ -37,24 +38,35 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+        // same phone number, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(BOB).withPhone(VALID_PHONE_ALICE).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).withUniversity(VALID_UNIVERSITY_BOB)
                 .withMajor(VALID_MAJOR_BOB).withInterests(VALID_INTEREST_BOB).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different phone number, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        // name differs in case, different phone, all other attributes same -> returns false
+        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).withPhone(VALID_PHONE_ALICE)
+                .build();
         assertFalse(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name differs in case, same phone, all other attributes same -> returns true
+        Person editedBobSamePhone = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSamePerson(editedBobSamePhone));
+
+        // name has trailing spaces, different phone, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).withPhone(VALID_PHONE_ALICE)
+                .build();
         assertFalse(BOB.isSamePerson(editedBob));
+
+        // name has trailing spaces, same phone, all other attributes same -> returns true
+        String nameWithTrailingSpacesSamePhone = VALID_NAME_BOB + " ";
+        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpacesSamePhone).build();
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test
@@ -72,43 +84,15 @@ public class PersonTest {
         // different type -> returns false
         assertFalse(ALICE.equals(5));
 
-        // different person -> returns false
-        assertFalse(ALICE.equals(BOB));
-
-        // different name -> returns false
-        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        // different person with same phone -> returns true
+        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+                .withUniversity(VALID_UNIVERSITY_BOB).withMajor(VALID_MAJOR_BOB)
+                .withInterests(VALID_INTEREST_AMY).withBirthday(VALID_BIRTHDAY_BOB).build();
+        assertTrue(ALICE.equals(editedAlice));
 
         // different phone -> returns false
         editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different email -> returns false
-        editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different address -> returns false
-        editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different tags -> returns false
-        editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different university -> returns false
-        editedAlice = new PersonBuilder(ALICE).withUniversity(VALID_UNIVERSITY_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different major -> returns false
-        editedAlice = new PersonBuilder(ALICE).withMajor(VALID_MAJOR_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        // different interests -> returns false
-        editedAlice = new PersonBuilder(ALICE).withInterests(VALID_INTEREST_AMY).build();
-        assertFalse(ALICE.equals(editedAlice));
-
-        //different birthday -> return false
-        editedAlice = new PersonBuilder(ALICE).withBirthday(VALID_BIRTHDAY_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -131,7 +115,7 @@ public class PersonTest {
     @Test
     public void testHashCodeDifferent() {
         // Test that two different persons return different hash codes
-        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
         assertFalse(ALICE.hashCode() == editedAlice.hashCode());
     }
 }


### PR DESCRIPTION
Fixes #116 
- Modified AddCommand and Person equality checks to consider two Persons as equal if they share the same phone number, regardless of other fields (e.g., name).
- Updated AddCommand equals() tests to reflect this change, verifying that two AddCommands are considered equal if they attempt to add Persons with the same phone number.
- Added test cases to ensure that AddCommand equality works as expected when Persons have different phone numbers.

This change allows adding contacts with the same name but different phone numbers, aligning with real-world scenarios where multiple people may share a name.
