### PR TITLE
Fix findi bugs

### DIFF
--- a/docs/team/chenle.md
+++ b/docs/team/chenle.md
@@ -37,7 +37,8 @@ Given below are my contributions to the project.
   * User Guide:
     * Added documentation for the `findi` feature (Pull request [\#132](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/132)).
   * Developer Guide:
-    * Added documentation for the user profile, value proposition, and user stories (Pull request [\#31](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/31)).
+    * Added documentation for the user profile, value proposition, and user stories (Pull request [\#31](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/31)). 
+    * Added documentation for the user stories and use cases for the `findw` and `findi` features (Pull request [\#172](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/172)).
   
 * **Project management**:
   * Scheduling and Tracking: Initiated weekly meetings, took detailed meeting notes, assigned tasks, and tracked progress throughout the project.

--- a/docs/team/chenle.md
+++ b/docs/team/chenle.md
@@ -33,6 +33,15 @@ Given below are my contributions to the project.
   * DocumentationBug: Extra commas displayed in the search result message (Issue [\#133](https://github.com/AY2425S1-CS2103T-T17-1/tp/issues/133)).
   * FeatureFlaw: Restriction on the “&” symbol in `workExperience` field limits the app’s real-world applicability (Issue [\#134](https://github.com/AY2425S1-CS2103T-T17-1/tp/issues/134)).
 
+* **Bug Fixing**: `findi` (Pull request [\#193](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/193))
+  * Simplified Search Functionality: Refactored the "find by interests" feature to allow only single interest searches, enhancing usability and reducing confusion for users. 
+  * Error Handling for Invalid Inputs: Implemented error messages for unsupported input formats, including:
+    - Multiple interest keywords separated by spaces. 
+    - Invalid command structures without proper prefixes. 
+  * Updated Command and Parser Classes: Modified `FindByInterestCommand` and `FindByInterestCommandParser` to accommodate the new single interest search logic and ensure compliance with the updated input requirements.
+  * Predicate Logic Adjustment: Streamlined the `InterestContainsKeywordsPredicate` to support the new searching mechanism by accepting a single keyword instead of handling multiple AND/OR conditions.
+  * Test Case Revisions: Enhanced the test cases in `FindByInterestCommandParserTest` and `FindByInterestCommandTest` to validate the new behavior of the feature, ensuring correct parsing and execution based on the updated requirements.
+  
 * **Documentation**:
   * User Guide:
     * Added documentation for the `findi` feature (Pull request [\#132](https://github.com/AY2425S1-CS2103T-T17-1/tp/pull/132)).

--- a/src/main/java/seedu/address/logic/parser/FindByInterestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindByInterestCommandParser.java
@@ -2,68 +2,58 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.address.logic.commands.FindByInterestCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.InterestContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindByInterestCommand object.
+ * Parses input arguments and creates a new {@link FindByInterestCommand} object.
+ *
+ * @throws ParseException if the user input does not conform to the expected format.
  */
+
 public class FindByInterestCommandParser implements Parser<FindByInterestCommand> {
 
-    // Pattern to match each i/ group, allowing spaces or commas within it
-    private static final Pattern INTEREST_KEYWORD_PATTERN = Pattern.compile("i/\\s*([^\\s]+(?:\\s*,\\s*[^\\s]+)*)");
-
     /**
-     * Parses the given {@code String} of arguments in the context of the FindByInterestCommand
-     * and returns a FindByInterestCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@link FindByInterestCommand}
+     * and returns a {@link FindByInterestCommand} object for execution.
      *
-     * @throws ParseException if the user input does not conform to the expected format
+     * @param args The input string containing the user's command and parameters.
+     * @return A {@link FindByInterestCommand} containing the parsed interest keyword for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
      */
     public FindByInterestCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
 
-        if (trimmedArgs.isEmpty()) {
+        // Check if the input is empty or doesn't start with the correct format ("i/")
+        if (trimmedArgs.isEmpty() || !trimmedArgs.startsWith("i/")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByInterestCommand.MESSAGE_USAGE));
         }
 
-        // Two lists: one for AND keywords, one for OR keywords
-        List<List<String>> andKeywords = new ArrayList<>();
-        List<String> orKeywords = new ArrayList<>();
+        // Extract the interest keyword after "i/" and trim any unnecessary spaces
+        String interestKeyword = trimmedArgs.substring(2).trim();
 
-        // Match all "i/..." patterns in the input
-        Matcher matcher = INTEREST_KEYWORD_PATTERN.matcher(trimmedArgs);
-
-        while (matcher.find()) {
-            // Extract the keyword group from the match
-            String keywordGroup = matcher.group(1).trim();
-
-            if (!keywordGroup.isEmpty()) {
-                // Check if there is a comma in the keyword group
-                if (keywordGroup.contains(",")) {
-                    // Split by commas to handle "AND" condition
-                    List<String> keywords = Arrays.asList(keywordGroup.split("\\s*,\\s*"));
-                    andKeywords.add(new ArrayList<>(keywords));
-                } else {
-                    // No comma present, treat it as an "OR" condition
-                    orKeywords.add(keywordGroup);
-                }
-            }
-        }
-
-        // If no valid keywords were found, throw a ParseException
-        if (andKeywords.isEmpty() && orKeywords.isEmpty()) {
+        // Ensure that the interest keyword is not empty after trimming
+        if (interestKeyword.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByInterestCommand.MESSAGE_USAGE));
         }
 
-        return new FindByInterestCommand(new InterestContainsKeywordsPredicate(andKeywords, orKeywords));
+        // Check for invalid formats, such as multiple interest keywords or extra 'i/' prefixes
+        if (interestKeyword.contains(",")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByInterestCommand.MESSAGE_USAGE));
+        }
+
+        // Check for multiple keywords without commas
+        if (interestKeyword.contains(" ")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindByInterestCommand.MESSAGE_USAGE));
+        }
+
+        // Return a new FindByInterestCommand with the valid interest keyword
+        return new FindByInterestCommand(new InterestContainsKeywordsPredicate(interestKeyword));
     }
 }
+

--- a/src/main/java/seedu/address/model/person/InterestContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/InterestContainsKeywordsPredicate.java
@@ -1,81 +1,48 @@
 package seedu.address.model.person;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Interest} matches the given OR keywords or AND groups.
+ * Tests that a {@code Person}'s {@code Interest} matches the specified keyword.
  */
 public class InterestContainsKeywordsPredicate implements Predicate<Person> {
-    private final List<List<String>> andKeywords;
-    private final List<String> orKeywords;
+    private final String keyword;
+
     /**
-     * Constructs an {@code InterestContainsKeywordsPredicate} with specified AND and OR keyword lists.
+     * Constructs an {@code InterestContainsKeywordsPredicate} with the specified keyword.
      *
-     * @param andKeywords A list of lists, where each inner list represents a group of keywords that must all be
-     *                    matched (AND condition). Each person must contain all keywords in at least one inner list
-     *                    to satisfy this condition.
-     * @param orKeywords A list of keywords where any single keyword can match (OR condition). A person satisfies
-     *                   this condition if they contain at least one of the keywords in this list.
+     * @param keyword A keyword to match against a person's interests.
      */
-    public InterestContainsKeywordsPredicate(List<List<String>> andKeywords, List<String> orKeywords) {
-        this.andKeywords = andKeywords;
-        this.orKeywords = orKeywords;
+    public InterestContainsKeywordsPredicate(String keyword) {
+        this.keyword = keyword.toLowerCase(); // Normalize to lower case for case-insensitive matching
     }
 
     @Override
     public boolean test(Person person) {
-        // If both keyword lists are empty, return false (no matches)
-        if (andKeywords.isEmpty() && orKeywords.isEmpty()) {
-            return false;
-        }
-
-        // Check the OR keywords: at least one keyword in orKeywords must match
-        boolean orMatch = orKeywords.isEmpty() || orKeywords.stream()
-                .anyMatch(keyword ->
-                        person.getInterests().stream()
-                                .anyMatch(interest -> interest.toString().toLowerCase().contains(keyword.toLowerCase()))
-                );
-
-        // Check the AND keywords: every group in andKeywords must have all keywords in the group matching
-        boolean andMatch = andKeywords.stream()
-                .allMatch(group ->
-                        group.stream()
-                                .allMatch(keyword ->
-                                        person.getInterests().stream()
-                                                .anyMatch(interest ->
-                                                        interest.toString().toLowerCase()
-                                                                .contains(keyword.toLowerCase()))
-                                )
-                );
-
-        // Both OR and AND conditions must be satisfied
-        return orMatch && andMatch;
+        // Check if the person's interests contain the specified keyword
+        return person.getInterests().stream()
+                .anyMatch(interest -> interest.toString().toLowerCase().contains(keyword));
     }
-
 
     @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
-
         if (!(other instanceof InterestContainsKeywordsPredicate)) {
             return false;
         }
-
         InterestContainsKeywordsPredicate otherPredicate = (InterestContainsKeywordsPredicate) other;
-        return andKeywords.equals(otherPredicate.andKeywords)
-                && orKeywords.equals(otherPredicate.orKeywords);
+        return keyword.equals(otherPredicate.keyword);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("andKeywords", andKeywords)
-                .add("orKeywords", orKeywords)
+                .add("keyword", keyword)
                 .toString();
     }
 }
+

--- a/src/test/java/seedu/address/logic/commands/FindByInterestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByInterestCommandTest.java
@@ -13,7 +13,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,15 +38,8 @@ public class FindByInterestCommandTest {
 
     @Test
     public void equals() {
-        List<List<String>> firstAndKeywords = Collections.singletonList(Arrays.asList("reading"));
-        List<String> firstOrKeywords = Arrays.asList("sports");
-        InterestContainsKeywordsPredicate firstPredicate = new InterestContainsKeywordsPredicate(firstAndKeywords,
-                firstOrKeywords);
-
-        List<List<String>> secondAndKeywords = Collections.singletonList(Arrays.asList("writing"));
-        List<String> secondOrKeywords = Arrays.asList("cooking");
-        InterestContainsKeywordsPredicate secondPredicate = new InterestContainsKeywordsPredicate(secondAndKeywords,
-                secondOrKeywords);
+        InterestContainsKeywordsPredicate firstPredicate = new InterestContainsKeywordsPredicate("reading");
+        InterestContainsKeywordsPredicate secondPredicate = new InterestContainsKeywordsPredicate("sports");
 
         FindByInterestCommand findFirstCommand = new FindByInterestCommand(firstPredicate);
         FindByInterestCommand findSecondCommand = new FindByInterestCommand(secondPredicate);
@@ -72,8 +64,7 @@ public class FindByInterestCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.emptyList());
+        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(" ");
         FindByInterestCommand command = new FindByInterestCommand(predicate);
 
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,24 +73,20 @@ public class FindByInterestCommandTest {
     }
 
     @Test
-    public void execute_singleOrKeyword_onePersonFound() {
-        // Assume ALICE has the interest "reading"
+    public void execute_singleKeyword_onePersonFound() {
         String expectedMessage = MESSAGE_PERSON_FOUND_INTEREST;
-        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(Collections.emptyList(),
-                Arrays.asList("reading"));
+        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate("football");
         FindByInterestCommand command = new FindByInterestCommand(predicate);
 
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
+        assertEquals(Collections.singletonList(BENSON), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_multipleOrKeywords_multiplePersonsFound() {
-        // Assume ALICE has "reading" and BOB has "sports"
+    public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_FOUND_INTEREST, 2);
-        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(Collections.emptyList(),
-                Arrays.asList("reading", "football"));
+        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate("reading");
         FindByInterestCommand command = new FindByInterestCommand(predicate);
 
         expectedModel.updateFilteredPersonList(predicate);
@@ -108,26 +95,8 @@ public class FindByInterestCommandTest {
     }
 
     @Test
-    public void execute_andKeywords_singlePersonFound() {
-        // Expect "Found 1 person that have similar interest" for exactly one result with AND keywords
-        String expectedMessage = MESSAGE_PERSON_FOUND_INTEREST;
-        List<List<String>> andKeywords = Collections.singletonList(Arrays.asList("reading", "swimming"));
-        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(andKeywords,
-                Collections.emptyList());
-        FindByInterestCommand command = new FindByInterestCommand(predicate);
-
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-
-        // Assuming ALICE has both "reading" and "music" as interests
-        assertEquals(Collections.singletonList(ALICE), model.getFilteredPersonList());
-    }
-
-    @Test
     public void toStringMethod() {
-        List<List<String>> andKeywords = Collections.singletonList(Arrays.asList("reading"));
-        List<String> orKeywords = Arrays.asList("sports");
-        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate(andKeywords, orKeywords);
+        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate("reading");
 
         FindByInterestCommand findCommand = new FindByInterestCommand(predicate);
         String expected = FindByInterestCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";

--- a/src/test/java/seedu/address/logic/commands/FindByInterestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByInterestCommandTest.java
@@ -95,6 +95,18 @@ public class FindByInterestCommandTest {
     }
 
     @Test
+    public void execute_noInterestsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate("journaling");
+        FindByInterestCommand command = new FindByInterestCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+
+    @Test
     public void toStringMethod() {
         InterestContainsKeywordsPredicate predicate = new InterestContainsKeywordsPredicate("reading");
 

--- a/src/test/java/seedu/address/logic/parser/FindByInterestCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindByInterestCommandParserTest.java
@@ -21,6 +21,13 @@ public class FindByInterestCommandParserTest {
     }
 
     @Test
+    public void parse_onlySpaces_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByInterestCommand.MESSAGE_USAGE));
+    }
+
+
+    @Test
     public void parse_validSingleKeyword_returnsFindByInterestCommand() {
         FindByInterestCommand expectedCommand = new FindByInterestCommand(
                 new InterestContainsKeywordsPredicate("Reading"));
@@ -34,6 +41,12 @@ public class FindByInterestCommandParserTest {
     }
 
     @Test
+    public void parse_invalidPrefix_throwsParseException() {
+        assertParseFailure(parser, "x/reading", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByInterestCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_multipleSpaces_returnsTrimmedFindByInterestCommand() {
         FindByInterestCommand expectedCommand = new FindByInterestCommand(
                 new InterestContainsKeywordsPredicate("Photography"));
@@ -43,6 +56,18 @@ public class FindByInterestCommandParserTest {
     @Test
     public void parse_multipleKeywordsWithoutComma_throwsParseException() {
         assertParseFailure(parser, "i/Reading i/Swimming", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByInterestCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleIPrefixes_throwsParseException() {
+        assertParseFailure(parser, "i/reading i/swimming", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByInterestCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidCommaInput_throwsParseException() {
+        assertParseFailure(parser, "i/reading, i/swimming", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindByInterestCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindByInterestCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindByInterestCommandParserTest.java
@@ -4,9 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindByInterestCommand;
@@ -19,72 +16,33 @@ public class FindByInterestCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        // Test for empty input
         assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindByInterestCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validSingleOrKeyword_returnsFindByInterestCommand() {
-        // Test with valid single OR keyword input
+    public void parse_validSingleKeyword_returnsFindByInterestCommand() {
         FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(Collections.emptyList(), Collections.singletonList("Reading")));
+                new InterestContainsKeywordsPredicate("Reading"));
         assertParseSuccess(parser, "i/Reading", expectedCommand);
     }
 
     @Test
-    public void parse_validMultipleOrKeywords_returnsFindByInterestCommand() {
-        // Test with multiple OR keywords
-        FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(Collections.emptyList(), Arrays.asList("Reading", "Writing")));
-        assertParseSuccess(parser, "i/Reading i/Writing", expectedCommand);
-    }
-
-    @Test
-    public void parse_validAndKeywords_returnsFindByInterestCommand() {
-        // Test with AND keywords (comma-separated in a single "i/" group)
-        FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(Collections.singletonList(Arrays.asList("Reading", "Writing")),
-                        Collections.emptyList()));
-        assertParseSuccess(parser, "i/Reading,Writing", expectedCommand);
-    }
-
-    @Test
-    public void parse_validAndOrCombination_returnsFindByInterestCommand() {
-        // Test with a combination of AND and OR keywords
-        FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(
-                        Collections.singletonList(Arrays.asList("Reading", "Writing")),
-                        Arrays.asList("Sports", "Music")));
-        assertParseSuccess(parser, "i/Reading,Writing i/Sports i/Music", expectedCommand);
-    }
-
-    @Test
     public void parse_invalidArgs_throwsParseException() {
-        // Test for missing prefix (e.g., 'i/')
         assertParseFailure(parser, "Reading", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 FindByInterestCommand.MESSAGE_USAGE));
     }
+
     @Test
     public void parse_multipleSpaces_returnsTrimmedFindByInterestCommand() {
-        // Test input with multiple spaces
         FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(Collections.emptyList(),
-                Collections.singletonList("Photography")));
+                new InterestContainsKeywordsPredicate("Photography"));
         assertParseSuccess(parser, " i/   Photography    ", expectedCommand);
     }
 
     @Test
-    public void parse_mixedComplexInput_returnsFindByInterestCommand() {
-        // Test with complex input including multiple AND and OR conditions with extra spaces
-        FindByInterestCommand expectedCommand = new FindByInterestCommand(
-                new InterestContainsKeywordsPredicate(
-                        Arrays.asList(
-                                Arrays.asList("Photography", "Travel"),
-                                Arrays.asList("Cooking", "Baking")
-                        ),
-                        Arrays.asList("Music", "Dancing") // OR group
-                ));
-        assertParseSuccess(parser, "i/Photography,Travel i/Music i/Dancing i/Cooking,Baking", expectedCommand);
+    public void parse_multipleKeywordsWithoutComma_throwsParseException() {
+        assertParseFailure(parser, "i/Reading i/Swimming", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindByInterestCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com")
             .withPhone("98765432").withWorkExp("Intern,Google,2024")
             .withTags("owesMoney", "friends").withUniversity("NTU").withMajor("Computer Science")
-            .withInterests("Football", "Gaming").withBirthday("01-11-2002").build();
+            .withInterests("Football", "Reading").withBirthday("01-11-2002").build();
 
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz")
             .withPhone("95352563").withEmail("heinz@example.com").withAddress("wall street")


### PR DESCRIPTION
1. **Simplified Search Functionality**: Refactored the "find by interests" feature to allow only single interest searches, enhancing usability and reducing confusion for users.

2. **Error Handling for Invalid Inputs**: Implemented error messages for unsupported input formats, including:

- Multiple interest keywords separated by spaces.
- Invalid command structures without proper prefixes.
- Updated Command and Parser Classes: Modified `FindByInterestCommand` and `FindByInterestCommandParser` to accommodate the new single interest search logic and ensure compliance with the updated input requirements.
- Predicate Logic Adjustment: Streamlined the `InterestContainsKeywordsPredicate` to support the new searching mechanism by accepting a single keyword instead of handling multiple AND/OR conditions.

3. **Test Case Revisions**: Enhanced the test cases in `FindByInterestCommandParserTest` and `FindByInterestCommandTest` to validate the new behavior of the feature, ensuring correct parsing and execution based on the updated requirements.

Fixes #192 